### PR TITLE
feat(images): pad and unpad images to support variable size images

### DIFF
--- a/image_latent_transformer/batch_image_encoder.py
+++ b/image_latent_transformer/batch_image_encoder.py
@@ -10,60 +10,21 @@ from image_latent_transformer.vision_utils import encode_images as utils_encode_
 from image_latent_transformer.vision_utils import image_encoder_size
 
 
-@torch.inference_mode()
-def crop_nested_pixels(pixels: torch.Tensor) -> list[list[torch.Tensor]]:
-    """
-    pixels: (B, L, C, H, W) with zero-padding around the true content.
-    Returns nested list of per-(b,l) crops with padding removed.
-    """
-    B, L, C, H, W = pixels.shape  # noqa: N806
-    # Nonzero mask per (H,W) ignoring channels
-    m = pixels.ne(0).any(dim=2).reshape(B * L, H, W)  # (N,H,W), bool
-    non_empty = m.any(dim=(1, 2))  # (N,)
-    if not bool(non_empty.any()):
-        return [[] for _ in range(B)]
-
-    m_sel = m[non_empty]  # (M,H,W)
-    # Row/col occupancy
-    row_any = m_sel.any(dim=2)  # (M,H)
-    col_any = m_sel.any(dim=1)  # (M,W)
-
-    # Tight bounds via argmax trick (first/last True)
-    # Cast to int to avoid ambiguity warnings; works on CPU/GPU
-    y1 = row_any.int().argmax(dim=1)  # (M,)
-    y2 = (H - 1) - row_any.flip(dims=[1]).int().argmax(dim=1)  # (M,)
-    x1 = col_any.int().argmax(dim=1)  # (M,)
-    x2 = (W - 1) - col_any.flip(dims=[1]).int().argmax(dim=1)  # (M,)
-
-    # Map flattened indices back to (b,l)
-    idxs = non_empty.nonzero(as_tuple=False).squeeze(1)  # (M,)
-    b_idx = torch.div(idxs, L, rounding_mode='floor')  # (M,)
-    l_idx = idxs.remainder(L)  # (M,)
-
-    crops: list[list[torch.Tensor]] = [[] for _ in range(B)]
-    # Ragged outputs => loop over M non-empty positions
-    for i in range(idxs.numel()):
-        b = int(b_idx[i])  # noqa: N806
-        l = int(l_idx[i])  # noqa: N806,E741
-        rr0 = int(y1[i])
-        rr1 = int(y2[i])
-        cc0 = int(x1[i])
-        cc1 = int(x2[i])
-        crops[b].append(pixels[b, l, :, rr0:rr1 + 1, cc0:cc1 + 1].contiguous())
-    return crops
-
-
 def encode_images(image_encoder: AutoModelForImageClassification,
-                  input_pixels: torch.Tensor,
+                  input_images: torch.Tensor,
+                  input_images_dimensions: torch.Tensor,
                   device: torch.device = None) -> torch.Tensor:
     """Image encoder should accept variable size images and return consistent embeddings."""
-    B, L, *_ = input_pixels.shape  # noqa: N806
+    B, L, *_ = input_images.shape  # noqa: N806
 
     # Recreate as list of lists if input is a nested tensor, cropping padding from each image
-    input_pixels = crop_nested_pixels(input_pixels)
+    nested_images = [
+        [img[:, :h, :w] for img, (h, w) in zip(images, dims) if h > 0 and w > 0]
+        for images, dims in zip(input_images, input_images_dimensions)
+    ]
 
     # Flatten images
-    all_images = list(chain.from_iterable(input_pixels))
+    all_images = list(chain.from_iterable(nested_images))
 
     # Re-arrange the embeddings to match the original batch structure
     embeddings = encode_images_group(image_encoder=image_encoder,
@@ -75,7 +36,7 @@ def encode_images(image_encoder: AutoModelForImageClassification,
     embeds = torch.zeros(B, L, hidden_size, device=device)
 
     # Vectorized split and assignment
-    split_sizes = [len(inner) for inner in input_pixels]
+    split_sizes = [len(inner) for inner in nested_images]
     split_embeddings = torch.split(embeddings, split_sizes, dim=0)
     for i, split_embed in enumerate(split_embeddings):
         embeds[i, :len(split_embed)] = split_embed

--- a/image_latent_transformer/batch_image_encoder.py
+++ b/image_latent_transformer/batch_image_encoder.py
@@ -7,13 +7,11 @@ from transformers.image_transforms import group_images_by_shape, reorder_images
 
 from image_latent_transformer.collator import stack_pad_tensors
 from image_latent_transformer.vision_utils import encode_images as utils_encode_images
-from image_latent_transformer.vision_utils import image_encoder_size
 
 
 def encode_images(image_encoder: AutoModelForImageClassification,
                   input_images: torch.Tensor,
-                  input_images_dimensions: torch.Tensor,
-                  device: torch.device = None) -> torch.Tensor:
+                  input_images_dimensions: torch.Tensor) -> torch.Tensor:
     """Image encoder should accept variable size images and return consistent embeddings."""
     B, L, *_ = input_images.shape  # noqa: N806
 
@@ -27,50 +25,42 @@ def encode_images(image_encoder: AutoModelForImageClassification,
     all_images = list(chain.from_iterable(nested_images))
 
     # Re-arrange the embeddings to match the original batch structure
-    embeddings = encode_images_group(image_encoder=image_encoder,
-                                     images=all_images,
-                                     device=device)
+    embeddings = encode_images_group(image_encoder=image_encoder, images=all_images)
 
-    hidden_size = image_encoder_size(image_encoder)
+    # Restructure the flat embeddings back into the nested format
+    embeds = embeddings.new_zeros((B, L, embeddings.size(-1)))
 
-    embeds = torch.zeros(B, L, hidden_size, device=device)
+    lengths = torch.tensor([len(inner) for inner in nested_images], device=embeddings.device)
+    row_idx = torch.repeat_interleave(torch.arange(B, device=embeddings.device), lengths)
+    col_idx = torch.cat([torch.arange(n, device=embeddings.device) for n in lengths.tolist()])
 
-    # Vectorized split and assignment
-    split_sizes = [len(inner) for inner in nested_images]
-    split_embeddings = torch.split(embeddings, split_sizes, dim=0)
-    for i, split_embed in enumerate(split_embeddings):
-        embeds[i, :len(split_embed)] = split_embed
+    # One fused write instead of a Python loop
+    embeds.index_put_((row_idx, col_idx), embeddings, accumulate=False)
 
     return embeds
 
 
 def encode_images_batch(image_encoder: AutoModelForImageClassification,
-                        images: Union[list[torch.Tensor], torch.Tensor],
-                        device: torch.device = None) -> torch.Tensor:
+                        images: Union[list[torch.Tensor], torch.Tensor]) -> torch.Tensor:
     if isinstance(images, list):
         images = stack_pad_tensors(images)
-
-    if device is not None:
-        images = images.to(device)
 
     # Encode images using the image encoder
     return utils_encode_images(image_encoder, images)
 
 
 def encode_images_sequentially(image_encoder: AutoModelForImageClassification,
-                               images: list[torch.Tensor],
-                               device: torch.device = None) -> torch.Tensor:
-    encoded_images = [encode_images_batch(image_encoder, image.unsqueeze(0), device=device) for image in images]
+                               images: list[torch.Tensor]) -> torch.Tensor:
+    encoded_images = [encode_images_batch(image_encoder, image.unsqueeze(0)) for image in images]
     return torch.cat(encoded_images, dim=0)
 
 
 def encode_images_group(image_encoder: AutoModelForImageClassification,
-                        images: list[torch.Tensor],
-                        device: torch.device = None) -> torch.Tensor:
+                        images: list[torch.Tensor]) -> torch.Tensor:
     grouped_images, grouped_images_index = group_images_by_shape(images, disable_grouping=False)
 
     # Encode each group separately
-    encoded_groups = {size: encode_images_batch(image_encoder=image_encoder, images=group, device=device)
+    encoded_groups = {size: encode_images_batch(image_encoder=image_encoder, images=group)
                       for size, group in grouped_images.items()}
 
     # Re-arrange the encoded images to match the original order

--- a/image_latent_transformer/collator.py
+++ b/image_latent_transformer/collator.py
@@ -76,6 +76,9 @@ def stack_pad_tensors(tensors: list[torch.Tensor], pad_value=0):  # noqa: C901
     return stack_pad_tensors_fast(tensors, pad_value=pad_value, dtype=dtype, device=device)
 
 
+def stack_pad_tensors_list(tensors_list: list[list[torch.Tensor]], pad_value=0):
+    return stack_pad_tensors([stack_pad_tensors(tensors, pad_value=pad_value) for tensors in tensors_list])
+
 def collate_fn(batch: list, pad_value=0):
     if not batch:
         return batch
@@ -86,12 +89,6 @@ def collate_fn(batch: list, pad_value=0):
 
     for key in keys:
         tensors = [item[key] for item in batch]
-
-        if key == "input_pixels":
-            # TODO: figure out how to collate, to improve speed of data transfer,
-            # or solve https://github.com/sign/image-latent-transformer/issues/1
-            collated[key] = tensors  # Not collated
-        else:
-            collated[key] = stack_pad_tensors(tensors, pad_value=pad_value)
+        collated[key] = stack_pad_tensors(tensors, pad_value=pad_value)
 
     return collated

--- a/image_latent_transformer/model.py
+++ b/image_latent_transformer/model.py
@@ -449,7 +449,8 @@ class ImageLatentTransformerForCausalLM(ImageLatentTransformer, GenerationMixin)
             attention_mask: torch.Tensor,
             processor: TextImageProcessor,
             max_generated_words: int = 50,
-            bytes_generation_config: Optional[GenerationConfig] = None):
+            bytes_generation_config: Optional[GenerationConfig] = None,
+            **_unused_kwargs):
         """
         Generate text sequences using iterative latent-then-bytes generation.
 

--- a/image_latent_transformer/model.py
+++ b/image_latent_transformer/model.py
@@ -118,10 +118,14 @@ class ImageLatentTransformer(PreTrainedModel):
             return False
         return torch.rand(1).item() < self.config.modality_dropout
 
-    def encode_images(self, input_pixels: torch.Tensor, device: torch.device) -> torch.Tensor:
+    def encode_images(self,
+                      input_images: torch.Tensor,
+                      input_images_dimensions: torch.Tensor,
+                      device: torch.device) -> torch.Tensor:
         """
         Args:
-            input_pixels: NestedTensor of tensors of images, where each inner list contains images for one sample
+            input_images: Tensor of nested images, where each inner list contains images for one sample
+            input_images_dimensions: (BATCH, LENGTH, 2) - Original dimensions of each image (height, width)
             device: Device to move the tensors to
         Returns:
             torch.Tensor: (BATCH, LENGTH, HIDDEN_DIM) - Image embeddings
@@ -129,11 +133,14 @@ class ImageLatentTransformer(PreTrainedModel):
 
         if self.image_encoder is None or self._should_drop_modality():
             # If image encoder is None, return zeros
-            B, L, *_, = input_pixels.shape  # noqa: N806
+            B, L, *_, = input_images.shape  # noqa: N806
             dtype = getattr(self.image_encoder, "dtype", self.latent_transformer.dtype)
             return torch.zeros((B, L, self.image_encoder_dim), device=device, dtype=dtype)
 
-        return encode_images(self.image_encoder, input_pixels=input_pixels, device=device)
+        return encode_images(self.image_encoder,
+                             input_images=input_images,
+                             input_images_dimensions=input_images_dimensions,
+                             device=device)
 
     def encode_texts(self, input_ids: torch.Tensor, attention_mask: torch.Tensor) -> torch.Tensor:
         """
@@ -168,10 +175,11 @@ class ImageLatentTransformer(PreTrainedModel):
     def encode_input(self,
                      input_ids: torch.Tensor,
                      attention_mask: torch.Tensor,
-                     input_pixels: torch.Tensor):
+                     input_images: torch.Tensor,
+                     input_images_dimensions: torch.Tensor):
         embeds = []
         if self.image_encoder_dim > 0:
-            image_embeds = self.encode_images(input_pixels, device=input_ids.device)
+            image_embeds = self.encode_images(input_images, input_images_dimensions, device=input_ids.device)
             logger.debug("Image embeddings shape: %s", image_embeds.shape)
             embeds.append(image_embeds)
 
@@ -200,7 +208,8 @@ class ImageLatentTransformer(PreTrainedModel):
                 input_ids: torch.Tensor,
                 input_attention_mask: torch.Tensor,
                 attention_mask: torch.Tensor,
-                input_pixels: list[list[torch.nested.Tensor]],
+                input_images: torch.Tensor,
+                input_images_dimensions: torch.Tensor,
                 position_ids: Optional[torch.Tensor] = None,
                 labels_input: Optional[torch.Tensor] = None,
                 labels_attention_mask: Optional[torch.Tensor] = None,
@@ -210,14 +219,15 @@ class ImageLatentTransformer(PreTrainedModel):
             input_ids: (BATCH, LENGTH, INPUT_TOKENS)
             input_attention_mask: Attention within a word (BATCH, LENGTH, INPUT_TOKENS)
             attention_mask: Attention across words (BATCH, 1, LENGTH, LENGTH)
-            input_pixels: List of lists of images, where each inner list contains images for one sample
+            input_images: (BATCH, LENGTH, CHANNELS, HEIGHT, WIDTH)
+            input_images_dimensions: (BATCH, LENGTH, 2)
             position_ids: (BATCH, LENGTH) - Position IDs for latent transformer (useful for sequence packing)
             labels_input: (BATCH, LENGTH, OUTPUT_TOKENS) - Input tokens for bytes decoder
             labels_attention_mask: (BATCH, LENGTH, OUTPUT_TOKENS) - Attention mask for labels
             labels_output: (BATCH, LENGTH, OUTPUT_TOKENS) - Target tokens for language modeling
         """
         # Embed images and texts
-        mapped_embeds = self.encode_input(input_ids, input_attention_mask, input_pixels)
+        mapped_embeds = self.encode_input(input_ids, input_attention_mask, input_images, input_images_dimensions)
 
         # Process the sequence with the latent transformer
         latent_outputs = self.latent_transformer(
@@ -394,9 +404,12 @@ class ImageLatentTransformerForCausalLM(ImageLatentTransformer, GenerationMixin)
         new_input_ids = tokenized_words.input_ids.unsqueeze(1)
         new_attention_mask = tokenized_words.attention_mask.unsqueeze(1)
 
-        new_input_pixels = processor.render_texts(words).unsqueeze(1)
+        new_input_images, new_input_images_dimensions = processor.render_texts(words)
+        new_input_images = new_input_images.unsqueeze(1)
+        new_input_images_dimensions = new_input_images_dimensions.unsqueeze(1)
 
-        new_encoded_input = self.encode_input(new_input_ids, new_attention_mask, new_input_pixels)
+        new_encoded_input = self.encode_input(new_input_ids, new_attention_mask,
+                                              new_input_images, new_input_images_dimensions)
 
         # Extend the encoded input with an empty tensor
         empty_word = torch.zeros_like(encoded_input[:, 0:1])
@@ -429,9 +442,10 @@ class ImageLatentTransformerForCausalLM(ImageLatentTransformer, GenerationMixin)
     @torch.no_grad()
     def generate(
             self,
-            input_pixels: torch.Tensor,
             input_ids: torch.Tensor,
             input_attention_mask: torch.Tensor,
+            input_images: torch.Tensor,
+            input_images_dimensions: torch.Tensor,
             attention_mask: torch.Tensor,
             processor: TextImageProcessor,
             max_generated_words: int = 50,
@@ -444,13 +458,13 @@ class ImageLatentTransformerForCausalLM(ImageLatentTransformer, GenerationMixin)
         2. Bytes decoder generates words using full HuggingFace generation capabilities
 
         In practice, this means:
-        1. self.encode_input(input_ids, attention_mask, input_pixels)
+        1. self.encode_input(input_ids, attention_mask, input_images)
         2. self.latent_transformer.generate(...) to get latent states
         3. self.bytes_decoder.generate(...) to generate a single word from latent states (sequence of bytes)
         4. Detokenize the generated bytes to get the final word
         5. Create a new input_ids tensor for the new bytes. new attention_mask,
-            and an input_pixels tensor only for the new word (using render_texts())
-        6. Call self.encode_input() again with the new input_ids, attention_mask, and input_pixels
+            and an input_images tensor only for the new word (using render_texts())
+        6. Call self.encode_input() again with the new input_ids, attention_mask, and input_images
         7. Concatenate the encoded input with the previous encoded input to form the
             new input for the next word generation
         8. Repeat from step 2 until max_generated_words is reached, or the generated word is just an EOS token.
@@ -458,9 +472,10 @@ class ImageLatentTransformerForCausalLM(ImageLatentTransformer, GenerationMixin)
         We utilize the HuggingFace generation cache to efficiently generate.
 
         Args:
-            input_pixels: List of lists of images, where each inner list contains images for one sample
             input_ids: Text input tokens (B, L, T) for encoding
             input_attention_mask: Attention within a word (B, L, T)
+            input_images: (BATCH, LENGTH, CHANNELS, HEIGHT, WIDTH)
+            input_images_dimensions: (BATCH, LENGTH, 2)
             attention_mask: Attention across words (BATCH, 1, LENGTH, LENGTH)
             processor: TextImageProcessor instance for tokenization and image processing
             max_generated_words: Maximum number of words to generate
@@ -473,10 +488,10 @@ class ImageLatentTransformerForCausalLM(ImageLatentTransformer, GenerationMixin)
         num_words = self._num_words_per_datum(input_attention_mask)
 
         # Track generated words per sample
-        all_generated_words = [[] for _ in range(len(input_pixels))]
+        all_generated_words = [[] for _ in range(len(input_images))]
 
         # Step 1: Encode initial input
-        encoded_input = self.encode_input(input_ids, input_attention_mask, input_pixels)
+        encoded_input = self.encode_input(input_ids, input_attention_mask, input_images, input_images_dimensions)
 
         past_key_values = None  # Initialize past key values for caching
 

--- a/image_latent_transformer/model.py
+++ b/image_latent_transformer/model.py
@@ -139,8 +139,7 @@ class ImageLatentTransformer(PreTrainedModel):
 
         return encode_images(self.image_encoder,
                              input_images=input_images,
-                             input_images_dimensions=input_images_dimensions,
-                             device=device)
+                             input_images_dimensions=input_images_dimensions)
 
     def encode_texts(self, input_ids: torch.Tensor, attention_mask: torch.Tensor) -> torch.Tensor:
         """

--- a/image_latent_transformer/model.py
+++ b/image_latent_transformer/model.py
@@ -17,11 +17,12 @@ from transformers import (
 from transformers.modeling_outputs import CausalLMOutput
 from transformers.models.auto.auto_factory import _get_model_class
 
-from image_latent_transformer.batch_image_encoder import encode_images, image_encoder_size
+from image_latent_transformer.batch_image_encoder import encode_images
 from image_latent_transformer.config import ImageLatentTransformerConfig
 from image_latent_transformer.pretokenizer.pretokenizer import WordStoppingCriteria
 from image_latent_transformer.processor import TextImageProcessor
 from image_latent_transformer.tokenizer.utf8 import UTF8Tokenizer
+from image_latent_transformer.vision_utils import image_encoder_size
 
 logger = logging.getLogger(__name__)
 

--- a/image_latent_transformer/renderer.py
+++ b/image_latent_transformer/renderer.py
@@ -74,9 +74,7 @@ def render_text(text: str,
     text_width, text_height = layout.get_pixel_size()
 
     # Add padding and round up to nearest multiple of 32
-    # width = dim_to_block_size(text_width + 10, block_size=block_size)
-    # TODO: remove once https://github.com/sign/image-latent-transformer/issues/1 is efficient
-    width = font_size * 16  # Assume max 16 characters for now
+    width = dim_to_block_size(text_width + 10, block_size=block_size)
 
     line_height = block_size
 

--- a/tests/test_batch_image_encoder.py
+++ b/tests/test_batch_image_encoder.py
@@ -9,9 +9,9 @@ from image_latent_transformer.batch_image_encoder import (
     encode_images_batch,
     encode_images_group,
     encode_images_sequentially,
-    image_encoder_size,
 )
 from image_latent_transformer.collator import stack_pad_tensors_list
+from image_latent_transformer.vision_utils import image_encoder_size
 
 MODELS = {
     "WinKawaks/vit-tiny-patch16-224": 192,

--- a/tests/test_model_generation.py
+++ b/tests/test_model_generation.py
@@ -30,7 +30,8 @@ def predict_texts(texts: list[str], model, processor, collator):
         outputs = model.generate(
             input_ids=batch["input_ids"],
             input_attention_mask=batch["input_attention_mask"],
-            input_pixels=batch["input_pixels"],
+            input_images=batch["input_images"],
+            input_images_dimensions=batch["input_images_dimensions"],
             attention_mask=batch["attention_mask"],
             processor=processor,
             max_generated_words=5

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -158,6 +158,12 @@ def test_get_words_and_labels_packed_vs_unpacked(processor):
     assert labels_packed == ['hello world test', 'world test', 'test', '']
     assert labels_unpacked == ['hello ', 'world ', 'test', '']
 
+def test_render_images_shape(processor):
+    texts = ["short", "a bit longer text"]
+    render = processor.render_texts(texts)
+
+    assert render.shape == (2, 3, 16, 192)
+
 
 def test_pretokenize_splits_control_tokens(processor):
     text = (f"{ControlTokens.ShiftOut}test{ControlTokens.ShiftIn}"

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -18,8 +18,9 @@ def processor():
 
 
 expected_tensor_keys = ["input_ids", "input_attention_mask", "attention_mask", "position_ids",
-                        "labels_input", "labels_attention_mask", "labels_output"]
-expected_keys = expected_tensor_keys + ["input_pixels"]
+                        "labels_input", "labels_attention_mask", "labels_output",
+                        "input_images", "input_images_dimensions"]
+expected_keys = expected_tensor_keys
 
 
 def test_processor_save_and_load_works(processor):
@@ -39,6 +40,7 @@ def test_processor_multiprocessing_pickle(processor):
 def test_processor_single_text_collated(processor):
     text = "example text for testing"
     inputs = processor(text, collated=True)
+
     assert all(key in inputs for key in expected_keys)
     assert all(isinstance(inputs[key], torch.Tensor) for key in expected_tensor_keys)
 
@@ -160,9 +162,10 @@ def test_get_words_and_labels_packed_vs_unpacked(processor):
 
 def test_render_images_shape(processor):
     texts = ["short", "a bit longer text"]
-    render = processor.render_texts(texts)
+    renders, dimensions = processor.render_texts(texts)
 
-    assert render.shape == (2, 3, 16, 192)
+    assert renders.shape == (2, 3, 16, 192)
+    assert torch.equal(dimensions, torch.tensor([[16, 192], [16, 192]]))
 
 
 def test_pretokenize_splits_control_tokens(processor):

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -164,8 +164,8 @@ def test_render_images_shape(processor):
     texts = ["short", "a bit longer text"]
     renders, dimensions = processor.render_texts(texts)
 
-    assert renders.shape == (2, 3, 16, 192)
-    assert torch.equal(dimensions, torch.tensor([[16, 192], [16, 192]]))
+    assert renders.shape == (2, 3, 16, 160)
+    assert torch.equal(dimensions, torch.tensor([[16, 64], [16, 160]]))
 
 
 def test_pretokenize_splits_control_tokens(processor):

--- a/training/sample.py
+++ b/training/sample.py
@@ -34,9 +34,10 @@ def sample(model_path: Path):
     inputs = processor(texts, collated=True, packed=False)
 
     outputs = model.generate(
-        input_pixels=inputs["input_pixels"],
         input_ids=inputs["input_ids"],
         input_attention_mask=inputs["input_attention_mask"],
+        input_images=inputs["input_images"],
+        input_images_dimensions=inputs["input_images_dimensions"],
         attention_mask=inputs["attention_mask"],
         processor=processor,
         max_generated_words=32,

--- a/training/sample.py
+++ b/training/sample.py
@@ -34,11 +34,7 @@ def sample(model_path: Path):
     inputs = processor(texts, collated=True, packed=False)
 
     outputs = model.generate(
-        input_ids=inputs["input_ids"],
-        input_attention_mask=inputs["input_attention_mask"],
-        input_images=inputs["input_images"],
-        input_images_dimensions=inputs["input_images_dimensions"],
-        attention_mask=inputs["attention_mask"],
+        **inputs,
         processor=processor,
         max_generated_words=32,
         bytes_generation_config=GenerationConfig(num_beams=2)  # Sample with beam search, for example


### PR DESCRIPTION
Towards #1 by going around it

Instead of having an attention mask for images, we pad all images to the max size, then use their dimensions to unpad them.

This is ~1.5-2x slower than the current implementation, so it is not yet merged.
